### PR TITLE
Refactor webpack; React boilerplate

### DIFF
--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export default function App() {
+  return (
+    <h1>App Component</h1>
+  )
+}

--- a/client/index.js
+++ b/client/index.js
@@ -1,14 +1,12 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
-// import { render } from "react-dom";
-// import App from "./components/App.jsx";
+import App from "./components/App.jsx";
 
-const container = document.getElementById('root');
+const container = document.getElementById("root");
 const root = createRoot(container);
 
 root.render(
-    <>
-    Text from index.js
-    {/* <App /> */}
-    </>
-)
+  <>
+    <App />
+  </>
+);

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "NODE_ENV=production & nodemon server/server.js",
+    "start": "NODE_ENV=production nodemon server/server.js",
     "build": "NODE_ENV=production webpack",
-    "dev": "NODE_ENV=development webpack serve --open & NODE_ENV=development nodemon server/server.js",
+    "dev": "NODE_ENV=development webpack serve & NODE_ENV=development nodemon server/server.js",
     "test": "jest --verbose"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "git+https://github.com/oslabs-beta/Datective.git"
   },
   "keywords": [],
-  "author": "Jamie Schiff, Mariam Zakariadze, Jonathan Huang, Jo Huang",
+  "author": "Jo Huang https://github.com/jochuang, Jonathan Huang https://github.com/JH51, Jamie Schiff https://github.com/jamieschiff, Mariam Zakariadze https://github.com/mariamzakariadze",
   "license": "ISC",
   "bugs": {
     "url": "https://github.com/oslabs-beta/Datective/issues"

--- a/server/server.js
+++ b/server/server.js
@@ -1,21 +1,19 @@
 const express = require("express");
 const app = express();
-const path = require('path');
+const path = require("path");
 require("dotenv").config();
 
+const MODE = process.env.NODE_ENV || "production";
 const PORT = process.env.PORT || 3000;
 
 app.use(express.json());
 
-if (process.env.NODE_ENV === 'production') {
-  app.use("/dist", express.static(path.join(__dirname, '../dist')));
+if (MODE === "production") {
+  app.use("/", express.static(path.join(__dirname, "../dist")));
 }
 
-// serve index.html on the route '/'
-app.get('/', (req, res) => {
-  return res.status(200).sendFile(path.join(__dirname, '../dist/index.html'));
-});
-
 app.listen(PORT, () => {
-    console.log(`Express server listening on port ${PORT}\n${process.env.NODE_ENV.toUpperCase()} mode`);
+  console.log(
+    `Express server listening on port ${PORT}\n${MODE.toUpperCase()} mode`
+  );
 });

--- a/template.html
+++ b/template.html
@@ -5,7 +5,6 @@
     <title>Datective</title>
 </head>
 <body>
-    <h1>This header is coming from the template</h1>
     <div id="root"></div>
 </body>
 </html>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,23 +4,22 @@ const path = require("path");
 
 module.exports = {
   mode: process.env.NODE_ENV || "production",
+  entry: path.resolve(__dirname, "/client/index.js"),
+  output: {
+    path: path.resolve(__dirname, "dist"),
+    filename: "bundle.js",
+    publicPath: "/",
+  },
+  devtool: "source-map",
   devServer: {
-    hot: true,
-    proxy: {
-      "/": "http://localhost:3000",
-    },
     static: {
-      directory: path.resolve(__dirname, "./dist"),
+      directory: path.resolve(__dirname, "dist"),
     },
     port: 8080,
+    hot: true,
     open: true,
+    compress: true,
     historyApiFallback: true,
-  },
-  entry: path.resolve(__dirname, "./client/index.js"),
-  output: {
-    path: path.resolve(__dirname, "./dist"),
-    filename: "bundle.js",
-    publicPath: "/dist",
   },
   module: {
     rules: [
@@ -46,11 +45,4 @@ module.exports = {
       systemvars: true,
     }),
   ],
-  // resolve: {
-  //   fallback: {
-  //     fs: false,
-  //     os: false,
-  //     path: false,
-  //   },
-  // },
 };


### PR DESCRIPTION
- reconfigured webpack
- production and development servers should now serve at `localhost:PORT/`
- webpack dev server live-reloads and is independent of whether `npm run build` has been previously run (`dist/` can be empty)
- added source-maps devtool for accurate line numbers
- changed scripts in `package.json`
- created `App` component; attachment point for any subcomponents